### PR TITLE
Removed extra comma from basicOptions in TabLine

### DIFF
--- a/DistanceAndDirection/views/TabLine.js
+++ b/DistanceAndDirection/views/TabLine.js
@@ -122,7 +122,7 @@ define([
               directionPixelBuffer: 40,
               showDirectionalSymbols: false,
               showStartSymbol: true,
-              showEndSymbol: true,
+              showEndSymbol: true
           };            
           basicOptions = dojoLang.mixin(basicOptions, this.lineSymbol);
           this._lineSym = new DirectionalLineSymbol(basicOptions);


### PR DESCRIPTION
Removed extra comma from parameter in the basicOptions for the DirectionalLineSymbol class.